### PR TITLE
Send Spotify Env to Elm

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,28 @@ so that development scripts can run correctly
 npm install -g elm elm-format create-elm-app
 ```
 
+## Environment Variables
+
+*Note: Sorry for long name but `create-elm-app` need `ELM_APP` prefixed name
+to make it available inside NodeJS environment.*
+
+- ELM_APP_SPOTIFY_CLIENT_ID Spotify client ID
+- ELM_APP_SPOTIFY_SECRET Spotify client secret
+
 ## Local Development Server
 To run your local development server:
 
-TODO: add environment variables
 ```
+ELM_APP_SPOTIFY_CLIENT_ID=<Spotify client ID> \
+ELM_APP_SPOTIFY_SECRET=<Spotify client secret> \
 elm-app start
 ```
 
 ## Production Build
 To build the assets for production deployment, run `build` script:
 
-TODO: add environment variables
 ```
+ELM_APP_SPOTIFY_CLIENT_ID=<Spotify client ID> \
+ELM_APP_SPOTIFY_SECRET=<Spotify client secret> \
 elm-app build
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ so that development scripts can run correctly
 npm install -g elm elm-format create-elm-app
 ```
 
+## Local Development Server
+To run your local development server:
+
+TODO: add environment variables
+```
+elm-app start
+```
+
 ## Production Build
 To build the assets for production deployment, run `build` script:
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -14,12 +14,18 @@ type alias Flags =
 
 
 type alias Model =
-    {}
+    { spotifyClientId : String
+    , spotifySecret : String
+    }
 
 
 init : Flags -> ( Model, Cmd Msg )
 init flags =
-    ( {}, Cmd.none )
+    ( { spotifyClientId = flags.spotifyClientId
+      , spotifySecret = flags.spotifySecret
+      }
+    , Cmd.none
+    )
 
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -10,7 +10,7 @@ import Html.Attributes exposing (src)
 
 
 type alias Flags =
-    { spotifyClientId : String }
+    { spotifyClientId : String, spotifySecret : String }
 
 
 type alias Model =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,19 +1,24 @@
-module Main exposing (..)
+module Main exposing (Model, Msg(..), init, main, update, view)
 
 import Browser
-import Html exposing (Html, text, div, h1, img)
+import Html exposing (Html, div, h1, img, text)
 import Html.Attributes exposing (src)
 
 
+
 ---- MODEL ----
+
+
+type alias Flags =
+    { spotifyClientId : String }
 
 
 type alias Model =
     {}
 
 
-init : ( Model, Cmd Msg )
-init =
+init : Flags -> ( Model, Cmd Msg )
+init flags =
     ( {}, Cmd.none )
 
 
@@ -46,11 +51,11 @@ view model =
 ---- PROGRAM ----
 
 
-main : Program () Model Msg
+main : Program Flags Model Msg
 main =
     Browser.element
         { view = view
-        , init = \_ -> init
+        , init = init
         , update = update
         , subscriptions = always Sub.none
         }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,10 @@ import { Elm } from './Main.elm';
 // import registerServiceWorker from './registerServiceWorker';
 
 Elm.Main.init({
-  node: document.getElementById('root')
+  node: document.getElementById('root'),
+  flags: {
+    spotifyClientId: process.env.ELM_APP_SPOTIFY_CLIENT_ID
+  }
 });
 
 // registerServiceWorker();

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ import { Elm } from './Main.elm';
 Elm.Main.init({
   node: document.getElementById('root'),
   flags: {
-    spotifyClientId: process.env.ELM_APP_SPOTIFY_CLIENT_ID
+    spotifyClientId: process.env.ELM_APP_SPOTIFY_CLIENT_ID,
+    spotifySecret: process.env.ELM_APP_SPOTIFY_SECRET
   }
 });
 


### PR DESCRIPTION
The app needs two Spotify values to work:
- ELM_APP_SPOTIFY_CLIENT_ID Spotify client ID
- ELM_APP_SPOTIFY_SECRET Spotify client secret

This PR sent those two to Elm via flags